### PR TITLE
Don't use old single-quote package separator

### DIFF
--- a/bibtex2web.html
+++ b/bibtex2web.html
@@ -160,8 +160,11 @@ several additional BibTeX fields:
 		&ldquo;.key&rdquo;,
 		&ldquo;.ppt&rdquo;, &ldquo;.pptx&rdquo;,
 		&ldquo;.odp&rdquo;,
+		&ldquo;.mp4&rdquo;,
 		and also &ldquo;-slides.*&rdquo; or
-		&ldquo;-slides.*&rdquo; with any of the preceding extensions.
+		&ldquo;-talk.*&rdquo; or
+		&ldquo;-poster.*&rdquo;
+		with any of the preceding extensions.
 		You must put these files in the destination directory before
 		running the programs.  The basefilename is also used for
 		the per-article webpage (which includes the abstract).  If

--- a/bibtex2web.html
+++ b/bibtex2web.html
@@ -160,9 +160,11 @@ several additional BibTeX fields:
 		&ldquo;.key&rdquo;,
 		&ldquo;.ppt&rdquo;, &ldquo;.pptx&rdquo;,
 		&ldquo;.odp&rdquo;,
+		&ldquo;.mov&rdquo;,
 		&ldquo;.mp4&rdquo;,
-		and also &ldquo;-slides.*&rdquo; or
-		&ldquo;-talk.*&rdquo; or
+		and also
+                &ldquo;-slides.*&rdquo;,
+		&ldquo;-talk.*&rdquo;, or
 		&ldquo;-poster.*&rdquo;
 		with any of the preceding extensions.
 		You must put these files in the destination directory before

--- a/bin/bwconv.pl
+++ b/bin/bwconv.pl
@@ -573,9 +573,9 @@ sub set_supersedes ( $$$ ) {
       }
       my $newrec = $citekeys{$next_superseder};
       if (! defined($newrec)) {
-	my $msg = "Didn't find citekey $next_superseder which is referenced by $superseded_key";
-	print STDERR "$msg\n";
-	print STDERR "Known keys: \n  " . (join "\n  ", keys %citekeys) . "\n";
+        my $msg = "Didn't find citekey $next_superseder which is referenced by $superseded_key";
+        print STDERR "$msg\n";
+        print STDERR "Known keys: \n  " . (join "\n  ", keys %citekeys) . "\n";
         die $msg;
       }
       # print STDERR "looked up $next_superseder and got: $newrec\n";

--- a/lib/bp-cs-apple.pl
+++ b/lib/bp-cs-apple.pl
@@ -14,8 +14,8 @@ package bp_cs_apple;
 
 $bib::charsets{'apple', 'i_name'} = 'apple';
 
-$bib::charsets{'apple', 'tocanon'}  = "bp_cs_apple'tocanon";
-$bib::charsets{'apple', 'fromcanon'} = "bp_cs_apple'fromcanon";
+$bib::charsets{'apple', 'tocanon'}  = "bp_cs_apple::tocanon";
+$bib::charsets{'apple', 'fromcanon'} = "bp_cs_apple::fromcanon";
 
 $bib::charsets{'apple', 'toesc'}   = "[\200-\377]";
 $bib::charsets{'apple', 'fromesc'} = "[\200-\377]|${bib::cs_ext}|${bib::cs_meta}";

--- a/lib/bp-cs-auto.pl
+++ b/lib/bp-cs-auto.pl
@@ -16,8 +16,8 @@ package bp_cs_auto;
 
 $bib::charsets{'auto', 'i_name'} = 'auto';
 
-$bib::charsets{'auto', 'tocanon'}  = "bp_cs_auto'tocanon";
-$bib::charsets{'auto', 'fromcanon'} = "bp_cs_auto'fromcanon";
+$bib::charsets{'auto', 'tocanon'}  = "bp_cs_auto::tocanon";
+$bib::charsets{'auto', 'fromcanon'} = "bp_cs_auto::fromcanon";
 
 ######
 

--- a/lib/bp-cs-canon.pl
+++ b/lib/bp-cs-canon.pl
@@ -12,8 +12,8 @@ package bp_cs_canon;
 
 $bib::charsets{'canon', 'i_name'} = 'canon';
 
-$bib::charsets{'canon', 'tocanon'}  = "bp_cs_canon'tocanon";
-$bib::charsets{'canon', 'fromcanon'} = "bp_cs_canon'fromcanon";
+$bib::charsets{'canon', 'tocanon'}  = "bp_cs_canon::tocanon";
+$bib::charsets{'canon', 'fromcanon'} = "bp_cs_canon::fromcanon";
 
 $bib::charsets{'canon', 'toesc'}   = "[\000]";  # we'd prefer to never call it
 $bib::charsets{'canon', 'fromesc'} = "[\000]";

--- a/lib/bp-cs-dead.pl
+++ b/lib/bp-cs-dead.pl
@@ -30,8 +30,8 @@ package bp_cs_dead;
 
 $bib::charsets{'dead', 'i_name'} = 'dead';
 
-$bib::charsets{'dead', 'tocanon'}   = "bp_cs_dead'tocanon";
-$bib::charsets{'dead', 'fromcanon'} = "bp_cs_dead'fromcanon";
+$bib::charsets{'dead', 'tocanon'}   = "bp_cs_dead::tocanon";
+$bib::charsets{'dead', 'fromcanon'} = "bp_cs_dead::fromcanon";
 
 $bib::charsets{'dead', 'toesc'}   = "[\\\\]";
 $bib::charsets{'dead', 'fromesc'} = "[\\\200-\377]|${bib::cs_ext}|${bib::cs_meta}";

--- a/lib/bp-cs-html.pl
+++ b/lib/bp-cs-html.pl
@@ -533,7 +533,7 @@ sub fromcanon {
   # </ul> => </li></ul><p>
   s/(${bib::cs_meta}1311|${bib::cs_meta}1312)/${bib::cs_meta}1310\n$1\n${bib::cs_meta}1100/g;
   # </ul> might have been followed by <p> already.
-  s/${bib::cs_meta}1100 *\n${bib::cs_meta}1110\n\n${bib::cs_meta}1100/\n${bib::cs_meta}1100/g;
+  s/${bib::cs_meta}1100 *\n+${bib::cs_meta}1110\n+${bib::cs_meta}1100/\n${bib::cs_meta}1100/g;
 #  print $_;
 
   &init_cs_fr unless $cs_fr_init;

--- a/lib/bp-cs-html.pl
+++ b/lib/bp-cs-html.pl
@@ -532,6 +532,8 @@ sub fromcanon {
   s/(${bib::cs_meta}1301|${bib::cs_meta}1302)([ \n]*${bib::cs_meta}1310)/${bib::cs_meta}1110\n$1/g;
   # </ul> => </li></ul><p>
   s/(${bib::cs_meta}1311|${bib::cs_meta}1312)/${bib::cs_meta}1310\n$1\n${bib::cs_meta}1100/g;
+  # </ul> might have been followed by <p> already.
+  s/${bib::cs_meta}1100 *\n${bib::cs_meta}1110\n\n${bib::cs_meta}1100/\n${bib::cs_meta}1100/g;
 #  print $_;
 
   &init_cs_fr unless $cs_fr_init;

--- a/lib/bp-cs-html.pl
+++ b/lib/bp-cs-html.pl
@@ -57,8 +57,8 @@ package bp_cs_html;
 
 $bib::charsets{'html', 'i_name'} = 'html';
 
-$bib::charsets{'html', 'tocanon'}   = "bp_cs_html'tocanon";
-$bib::charsets{'html', 'fromcanon'} = "bp_cs_html'fromcanon";
+$bib::charsets{'html', 'tocanon'}   = "bp_cs_html::tocanon";
+$bib::charsets{'html', 'fromcanon'} = "bp_cs_html::fromcanon";
 
 # This is a regex to search for.  If it succeeds, then we call the routine.
 # otherwise not.  If it is set to undef, the routine is always called.

--- a/lib/bp-cs-none.pl
+++ b/lib/bp-cs-none.pl
@@ -12,8 +12,8 @@ package bp_cs_none;
 
 $bib::charsets{'none', 'i_name'} = 'none';
 
-$bib::charsets{'none', 'tocanon'}  = "bp_cs_none'tocanon";
-$bib::charsets{'none', 'fromcanon'} = "bp_cs_none'fromcanon";
+$bib::charsets{'none', 'tocanon'}  = "bp_cs_none::tocanon";
+$bib::charsets{'none', 'fromcanon'} = "bp_cs_none::fromcanon";
 
 $bib::charsets{'none', 'toesc'}   = "[\000]";
 $bib::charsets{'none', 'fromesc'} = "[\x00-\x1F\200-\377]|${bib::cs_ext}|${bib::cs_meta}";

--- a/lib/bp-cs-tex.pl
+++ b/lib/bp-cs-tex.pl
@@ -29,8 +29,8 @@ package bp_cs_tex;
 
 $bib::charsets{'tex', 'i_name'} = 'tex';
 
-$bib::charsets{'tex', 'tocanon'}   = "bp_cs_tex'tocanon";
-$bib::charsets{'tex', 'fromcanon'} = "bp_cs_tex'fromcanon";
+$bib::charsets{'tex', 'tocanon'}   = "bp_cs_tex::tocanon";
+$bib::charsets{'tex', 'fromcanon'} = "bp_cs_tex::fromcanon";
 
 # This regexp should match any (La)TeX character that needs to be escaped.
 $bib::charsets{'tex', 'toesc'}   = "([\$\\\\]|``|''|---)";
@@ -518,7 +518,7 @@ sub fromcanon {
 
   my $repl;
   # We no longer check for font matching here, as that should be done by a
-  # call to bib'font_check in the tocanon code.
+  # call to bib::font_check in the tocanon code.
 
   $text =~ s/${bib::cs_meta}2200${bib::cs_meta}2300([^{}]+)${bib::cs_meta}2310\1${bib::cs_meta}2210/\\url\{$1\}/g;
   $text =~ s/${bib::cs_meta}2200${bib::cs_meta}2300([^{}]+)${bib::cs_meta}2310([^{}]+)${bib::cs_meta}2210/\\href\{$1\}\{$2\}/g;

--- a/lib/bp-cs-tex.pl
+++ b/lib/bp-cs-tex.pl
@@ -544,7 +544,7 @@ sub fromcanon {
   while ($text =~ /([\200-\237])/) {
     $repl = $1;
     $unicode = &bib::canon_to_unicode($repl);
-    &bib::gotwarn("Can't convert ".&bib::unicode_name($unicode)." to TeX");
+    &bib::gotwarn("Can't convert ".&bib::unicode_name($unicode)." to TeX in $text");
     $text =~ s/$repl//g;
   }
 
@@ -584,7 +584,7 @@ sub fromcanon {
     $can = &bib::unicode_approx($unicode);
     defined $can  &&  $text =~ s/$bib::cs_ext$unicode/$can/g  &&  next;
 
-    &bib::gotwarn("Can't convert ".&bib::unicode_name($unicode)." to TeX");
+    &bib::gotwarn("Can't convert ".&bib::unicode_name($unicode)." to TeX; text = $text; can = $can");
     $text =~ s/${bib::cs_ext}$unicode//g;
   }
 
@@ -596,7 +596,7 @@ sub fromcanon {
     $can = &bib::meta_approx($repl);
     defined $can  &&  $text =~ s/$bib::cs_meta$repl/$can/g  &&  next;
 
-    &bib::gotwarn("Can't convert ".&bib::meta_name($repl)." to TeX");
+    &bib::gotwarn("Can't convert ".&bib::meta_name($repl)." to TeX; text = $text; can = $can");
     $text =~ s/${bib::cs_meta}$repl//g;
   }
 

--- a/lib/bp-cs-troff.pl
+++ b/lib/bp-cs-troff.pl
@@ -318,22 +318,14 @@ sub tocanon {
 
   eval $cmap_eval;
 
-  print STDERR "now (1) $_\n";
-
   return $_  unless /\\/;
-
-  print STDERR "now (2) $_\n";
 
   # OK, they've got something fairly weird.
 
   # Handle the different ways of specifying characters
   eval $cmap_to_eval;
 
-  print STDERR "now (3) $_\n";
-
   return $_  unless /\\/;
-
-  print STDERR "now (4) $_\n";
 
   if (/\\f[123RIBP]/) {
     # font changes
@@ -353,11 +345,7 @@ sub tocanon {
     s/$mine/${bib::cs_meta}$can/g;
   }
 
-  print STDERR "now (5) $_\n";
-
   return $_  unless /\\/;
-
-  print STDERR "now (6) $_\n";
 
   # Last of all, the escape character.  First we check to see if there is
   # anything else.  We can't delete it because of the way troff does it's
@@ -367,8 +355,6 @@ sub tocanon {
   }
   # Then convert the escape character
   s/\\e/\\/g;
-
-  print STDERR "now (7) $_\n";
 
   $_;
 }

--- a/lib/bp-cs-troff.pl
+++ b/lib/bp-cs-troff.pl
@@ -318,14 +318,22 @@ sub tocanon {
 
   eval $cmap_eval;
 
+  print STDERR "now (1) $_\n";
+
   return $_  unless /\\/;
+
+  print STDERR "now (2) $_\n";
 
   # OK, they've got something fairly weird.
 
   # Handle the different ways of specifying characters
   eval $cmap_to_eval;
 
+  print STDERR "now (3) $_\n";
+
   return $_  unless /\\/;
+
+  print STDERR "now (4) $_\n";
 
   if (/\\f[123RIBP]/) {
     # font changes
@@ -345,7 +353,11 @@ sub tocanon {
     s/$mine/${bib::cs_meta}$can/g;
   }
 
+  print STDERR "now (5) $_\n";
+
   return $_  unless /\\/;
+
+  print STDERR "now (6) $_\n";
 
   # Last of all, the escape character.  First we check to see if there is
   # anything else.  We can't delete it because of the way troff does it's
@@ -355,6 +367,8 @@ sub tocanon {
   }
   # Then convert the escape character
   s/\\e/\\/g;
+
+  print STDERR "now (7) $_\n";
 
   $_;
 }

--- a/lib/bp-cs-troff.pl
+++ b/lib/bp-cs-troff.pl
@@ -13,8 +13,8 @@ package bp_cs_troff;
 
 $bib::charsets{'troff', 'i_name'} = 'troff';
 
-$bib::charsets{'troff', 'tocanon'}  = "bp_cs_troff'tocanon";
-$bib::charsets{'troff', 'fromcanon'} = "bp_cs_troff'fromcanon";
+$bib::charsets{'troff', 'tocanon'}  = "bp_cs_troff::tocanon";
+$bib::charsets{'troff', 'fromcanon'} = "bp_cs_troff::fromcanon";
 
 $bib::charsets{'troff', 'toesc'}   = '[\\\\]';
 $bib::charsets{'troff', 'fromesc'} = "[\\\\\200-\377]|${bib::cs_ext}|${bib::cs_meta}";

--- a/lib/bp-htmlabstract.pl
+++ b/lib/bp-htmlabstract.pl
@@ -204,7 +204,6 @@ sub fromcanon {
 #  }
   # Adjust formatting of the abstract, and insert $prev_versions.
   $text =~ s/${bib::cs_meta}1103${bib::cs_meta}0103Abstract:  ${bib::cs_meta}0113\n(.*)${bib::cs_meta}1113/$prev_versions${bib::cs_meta}1110\n\n${bib::cs_meta}2232Abstract${bib::cs_meta}2233\n\n${bib::cs_meta}1100\n$1\n\n/;
-
   # Convert 1120 into 1110 plus 1100
   $text =~ s/$cs_meta1120/\n$cs_meta1110\n\n$cs_meta1100\n/g;
   # Introduce line breaks

--- a/lib/bp-htmlabstract.pl
+++ b/lib/bp-htmlabstract.pl
@@ -203,6 +203,7 @@ sub fromcanon {
 #  }
   # Adjust formatting of the abstract, and insert $prev_versions.
   $text =~ s/${bib::cs_meta}1103${bib::cs_meta}0103Abstract:  ${bib::cs_meta}0113\n(.*)${bib::cs_meta}1113/$prev_versions${bib::cs_meta}1110\n\n${bib::cs_meta}2232Abstract${bib::cs_meta}2233\n\n${bib::cs_meta}1100\n$1\n\n/;
+
   # Convert 1120 into 1110 plus 1100
   $text =~ s/$cs_meta1120/\n$cs_meta1110\n\n$cs_meta1100\n/g;
   # Introduce line breaks

--- a/lib/bp-htmlabstract.pl
+++ b/lib/bp-htmlabstract.pl
@@ -250,11 +250,12 @@ sub fromcanon {
     }
   }
 
-  if (defined $downloads) {
+  if (defined $downloads && length $downloads) {
     $text .= "${bib::cs_meta}1100\n"; # paragraph start
     $text .= "$downloads";
-    $text .= "${bib::cs_meta}1110\n\n"; # end the paragraph
+    $text .= "${bib::cs_meta}1110\n"; # end the paragraph
   }
+  $text .= "\n";
 
   if ($opt_withbibtex) {
       my %bibentry;

--- a/lib/bp-htmlabstract.pl
+++ b/lib/bp-htmlabstract.pl
@@ -196,6 +196,7 @@ sub fromcanon {
 
   my $prev_versions = bp_htmlbw::previous_versions_text($title_author, %entry);
   $prev_versions = bp_htmlbw::join_linebreak("", $prev_versions);
+
   ## Problem:  if no abstract, then $prev_versions isn't inserted?
 # Do not add paragraph end; there might be downloads and such to come.
 #  if ($text !~ /${bib::cs_meta}1103${bib::cs_meta}0103Abstract:/) {

--- a/lib/bp-htmlabstract.pl
+++ b/lib/bp-htmlabstract.pl
@@ -315,7 +315,9 @@ sub fromcanon {
     }
   }
   $rec{'TEXT'} = $text;
-  # print "return value: $text\n";
+  if ($debug_htmlabstract) {
+    print "return value: $text\n";
+  }
   %rec;
 }
 

--- a/lib/bp-htmlabstract.pl
+++ b/lib/bp-htmlabstract.pl
@@ -111,10 +111,10 @@ sub make_href {
   my ($url, $title) = @_;
 
   return
-    "${bib'cs_meta}2200"
-    . "${bib'cs_meta}2300"
-    . $url   . "${bib'cs_meta}2310"
-    . $title . "${bib'cs_meta}2210";
+    "${bib::cs_meta}2200"
+    . "${bib::cs_meta}2300"
+    . $url   . "${bib::cs_meta}2310"
+    . $title . "${bib::cs_meta}2210";
 }
 
 my $csmeta = "${bib::cs_meta}";
@@ -150,7 +150,7 @@ sub fromcanon {
 #  print Dumper(\%entry);
 
   # Split across lines, to be more readable in the HTML file.
-  # This puts ${bib'cs_meta}1100 on line 1, title on line 2, authors on
+  # This puts ${bib::cs_meta}1100 on line 1, title on line 2, authors on
   # line 3, and all other info on line 4.
   $text =~ s/($cs_meta1100)/$1\n/;
   my $title_author;
@@ -220,7 +220,7 @@ sub fromcanon {
           # Prevent inserting an anchor even within another anchor.
           # It's undesirable, and HTML forbids such nesting.
           # (Using possessive quantifier anywhere in the regex would prevent backtracking everwhere.)
-          $prefix = "(^|${bib'cs_meta}2210)[^${bib'cs_escape}]*(${bib'cs_escape}(?!m2200)[^${bib'cs_escape}]*)*";
+          $prefix = "(^|${bib::cs_meta}2210)[^${bib::cs_escape}]*(${bib::cs_escape}(?!m2200)[^${bib::cs_escape}]*)*";
           while ($text =~ s/$prefix\K\Q$linkname\E/&make_href($lurl, $linkname)/ges) {
             # no body
           }

--- a/lib/bp-htmlabstract.pl
+++ b/lib/bp-htmlabstract.pl
@@ -187,15 +187,15 @@ sub fromcanon {
   }
 
   my $downloads = bp_htmlbw::downloads_text($htmldir, 'no_abstract', %entry);
-  if (defined $downloads) {
+  if (defined $downloads && length $downloads) {
     # print STDERR "downloads (1): $downloads\n";
     $downloads =~ s/(Download:)\n/$cs_meta0103$1$cs_meta0113\n/;
     # print STDERR "downloads (2): $downloads\n";
     $text = "${bib::cs_meta}1100\n$downloads${bib::cs_meta}1110\n\n$text";
   }
+
   my $prev_versions = bp_htmlbw::previous_versions_text($title_author, %entry);
   $prev_versions = bp_htmlbw::join_linebreak("", $prev_versions);
-
   ## Problem:  if no abstract, then $prev_versions isn't inserted?
 # Do not add paragraph end; there might be downloads and such to come.
 #  if ($text !~ /${bib::cs_meta}1103${bib::cs_meta}0103Abstract:/) {

--- a/lib/bp-htmlbw.pl
+++ b/lib/bp-htmlbw.pl
@@ -96,6 +96,7 @@ sub downloads_text ( $$% ) {
 			       "ppt" => "PowerPoint",
 			       # "ppt.gz" => "PowerPoint (gzipped)",
 			       "odp" => "ODP",
+			       "mov" => ".mov",
 			       "mp4" => "MP4"
 			      );
 
@@ -105,6 +106,7 @@ sub downloads_text ( $$% ) {
                                "pptx", "ppt",
                                "key",
                                "odp",
+                               "mov",
                                "mp4"
                               );
 

--- a/lib/bp-htmlbw.pl
+++ b/lib/bp-htmlbw.pl
@@ -24,10 +24,10 @@ sub make_href {
   my ($url, $title) = @_;
 
   return
-    "${bib'cs_meta}2200"
-    . "${bib'cs_meta}2300"
-    . $url   . "${bib'cs_meta}2310"
-    . $title . "${bib'cs_meta}2210";
+    "${bib::cs_meta}2200"
+    . "${bib::cs_meta}2300"
+    . $url   . "${bib::cs_meta}2310"
+    . $title . "${bib::cs_meta}2210";
 }
 
 # Either return the first argument (if second is missing), or

--- a/lib/bp-htmlbw.pl
+++ b/lib/bp-htmlbw.pl
@@ -96,6 +96,7 @@ sub downloads_text ( $$% ) {
 			       "ppt" => "PowerPoint",
 			       # "ppt.gz" => "PowerPoint (gzipped)",
 			       "odp" => "ODP",
+			       "mov" => ".mov"
 			       "mp4" => "MP4"
 			      );
 
@@ -105,6 +106,7 @@ sub downloads_text ( $$% ) {
                                "pptx", "ppt",
                                "key",
                                "odp",
+                               "mov"
                                "mp4"
                               );
 

--- a/lib/bp-htmlbw.pl
+++ b/lib/bp-htmlbw.pl
@@ -84,6 +84,7 @@ sub downloads_text ( $$% ) {
     }
 
     my @local_downloads = ();
+    # These do not include text like "slides" or "talk video".
     my %download_type_names = (
 			       "pdf" => "PDF",
 			       # "pdf.gz" => "PDF (gzipped)",
@@ -94,7 +95,8 @@ sub downloads_text ( $$% ) {
 			       "pptx" => "PowerPoint",
 			       "ppt" => "PowerPoint",
 			       # "ppt.gz" => "PowerPoint (gzipped)",
-			       "odp" => "ODP"
+			       "odp" => "ODP",
+			       "mp4" => "MP4"
 			      );
 
 
@@ -102,9 +104,11 @@ sub downloads_text ( $$% ) {
 			       "doc", "docx",
                                "pptx", "ppt",
                                "key",
-                               "odp");
+                               "odp",
+                               "mp4"
+                              );
 
-    foreach my $doctype ("slides", "poster", "base") {
+    foreach my $doctype ("slides", "talk", "poster", "base") {
       # These get unshifted in, so reverse the order so they appear
       # on the page properly.
       foreach my $dtype (reverse @download_type_order) {
@@ -115,6 +119,11 @@ sub downloads_text ( $$% ) {
 	if ($doctype eq "slides") {
 	  $fn_ext = "-slides";
 	  $label = "slides (${dtn})";
+	}
+
+	if ($doctype eq "talk") {
+	  $fn_ext = "-talk";
+	  $label = "talk video (${dtn})";
 	}
 
 	if ($doctype eq "poster") {

--- a/lib/bp-htmllist.pl
+++ b/lib/bp-htmllist.pl
@@ -68,7 +68,7 @@ sub options {
     return undef;
 }
 
-my $csmeta = ${bib'cs_meta};
+my $csmeta = ${bib::cs_meta};
 
 my $prev_category = undef;
 
@@ -76,10 +76,10 @@ sub make_href {
   my ($url, $title) = @_;
 
   return
-    "${bib'cs_meta}2200"
-    . "${bib'cs_meta}2300"
-    . $url   . "${bib'cs_meta}2310"
-    . $title . "${bib'cs_meta}2210";
+    "${bib::cs_meta}2200"
+    . "${bib::cs_meta}2300"
+    . $url   . "${bib::cs_meta}2310"
+    . $title . "${bib::cs_meta}2210";
 }
 
 sub fromcanon {
@@ -109,7 +109,7 @@ sub fromcanon {
                        $title);
   }
 
-  my $text = "$title${bib'cs_meta}2150\n";
+  my $text = "$title${bib::cs_meta}2150\n";
 
   $numrecs++;
   my %rec = ();

--- a/lib/bp-htmlpubs.pl
+++ b/lib/bp-htmlpubs.pl
@@ -66,10 +66,10 @@ sub make_href {
   my ($url, $title) = @_;
 
   return
-    "${bib'cs_meta}2200"
-    . "${bib'cs_meta}2300"
-    . $url   . "${bib'cs_meta}2310"
-    . $title . "${bib'cs_meta}2210";
+    "${bib::cs_meta}2200"
+    . "${bib::cs_meta}2300"
+    . $url   . "${bib::cs_meta}2310"
+    . $title . "${bib::cs_meta}2210";
 }
 
 my $csmeta = ${bib::cs_meta};
@@ -91,7 +91,7 @@ my $lastyear = 0;
 sub make_header {
   my ($title) = @_;
   # returns <h2> $title </h2>
-  return "${bib'cs_meta}2232" . $title . "${bib'cs_meta}2233";
+  return "${bib::cs_meta}2232" . $title . "${bib::cs_meta}2233";
 }
 
 # Like fromcanon, but suppresses year processing
@@ -118,7 +118,7 @@ sub fromcanon {
 
   # Split across lines, to be more readable in the HTML source;
   # also add line breaks, for readability in a browser.
-  # This puts ${bib'cs_meta}1100 on line 1, title on line 2, authors on
+  # This puts ${bib::cs_meta}1100 on line 1, title on line 2, authors on
   # line 3, and all other info on line 4.
   $text =~ s/($cs_meta1100)/$1\n$cs_meta0103/;
   my $title_author;

--- a/lib/bp-htmlsummary.pl
+++ b/lib/bp-htmlsummary.pl
@@ -47,7 +47,7 @@ $bp_s_generic::smartquotes = 1;
 
 ######
 
-my $csmeta = ${bib'cs_meta};
+my $csmeta = ${bib::cs_meta};
 
 my $prev_category = undef;
 
@@ -55,10 +55,10 @@ sub make_href {
   my ($url, $title) = @_;
 
   return
-    "${bib'cs_meta}2200"
-    . "${bib'cs_meta}2300"
-    . $url   . "${bib'cs_meta}2310"
-    . $title . "${bib'cs_meta}2210";
+    "${bib::cs_meta}2200"
+    . "${bib::cs_meta}2300"
+    . $url   . "${bib::cs_meta}2310"
+    . $title . "${bib::cs_meta}2210";
 }
 
 sub make_aname {
@@ -69,10 +69,10 @@ sub make_aname {
   $name =~ s/\(//g;
   $name =~ s/\)//g;
   return
-    "${bib'cs_meta}2200"
-    . "${bib'cs_meta}2301"
-    . $name  . "${bib'cs_meta}2310"
-    . $title . "${bib'cs_meta}2210";
+    "${bib::cs_meta}2200"
+    . "${bib::cs_meta}2301"
+    . $name  . "${bib::cs_meta}2310"
+    . $title . "${bib::cs_meta}2210";
 }
 
 
@@ -212,8 +212,8 @@ sub fromcanon {
 #   # Well, almost.  We do care if we're using HTML, because we want a number
 #   # of special things done for it.  As of 0.2.2, we have glb_current_cset
 #   # set for us for fromcanon.
-#   if ($bib'glb_current_cset eq 'html') {
-#     #$ent = "${bib'cs_meta}1100\n";
+#   if ($bib::glb_current_cset eq 'html') {
+#     #$ent = "${bib::cs_meta}1100\n";
 #     if (defined $entry{'Source'}) {
 #       my ($url, $title);
 #       $url = $entry{'Source'};
@@ -221,9 +221,9 @@ sub fromcanon {
 #       $url =~ s/^url:\s*(.*)/$1/i;
 #       if ($url =~ /^\w+:\/\//) {
 #         $title = $entry{'Title'};
-#         $entry{'Title'} = "${bib'cs_meta}2200" . "${bib'cs_meta}2300"
-#                         . $url   . "${bib'cs_meta}2310"
-#                         . $title . "${bib'cs_meta}2210";
+#         $entry{'Title'} = "${bib::cs_meta}2200" . "${bib::cs_meta}2300"
+#                         . $url   . "${bib::cs_meta}2310"
+#                         . $title . "${bib::cs_meta}2210";
 #       }
 #     }
 #   }
@@ -238,7 +238,7 @@ sub fromcanon {
 #   $ent .= &$conv_func(%entry);
 #
 #   #$ent =~ s/\s\s+/ /g;
-#   $ent =~ s/$bib'cs_sep/ ; /go;
+#   $ent =~ s/$bib::cs_sep/ ; /go;
 #
 #   $rec{'TEXT'} = $ent;
 #

--- a/lib/bp-p-cs.pl
+++ b/lib/bp-p-cs.pl
@@ -6,7 +6,7 @@
 # Dana Jacobsen (dana@acm.org)
 # 18 November 1995 (last modified 17 March 1996)
 
-# for bib'nocharset which calls fromcanon:
+# for bib::nocharset which calls fromcanon:
 require "bp-cs-none.pl";
 
 ######
@@ -215,9 +215,9 @@ sub font_check {
             &bib::gotwarn("Nesting problem.  Ended $font after $pfont");
             # just make it end the previous one.
             if ($] >= 5.000) {
-              s/(${bib::cs_meta}010$pfont)(.*?)${bib::cs_meta}011$font/$1$2{bib'cs_meta}011$pfont/;
+              s/(${bib::cs_meta}010$pfont)(.*?)${bib::cs_meta}011$font/$1$2{bib::cs_meta}011$pfont/;
             } else {
-              s/(${bib::cs_meta}010$pfont)(.*)${bib::cs_meta}011$font/$1$2{bib'cs_meta}011$pfont/;
+              s/(${bib::cs_meta}010$pfont)(.*)${bib::cs_meta}011$font/$1$2{bib::cs_meta}011$pfont/;
             }
             $fontsmatch = 0;
             last;
@@ -249,9 +249,9 @@ sub font_check {
         $pfont = pop(@fontstack);
 #print STDERR "F: Too many begins found roman & replacing with $pfont\n";
         if ($] >= 5.000) {
-          s/(${bib::cs_meta}010$pfont)(.*?)${bib::cs_meta}0111/$1$2{bib'cs_meta}011$pfont/;
+          s/(${bib::cs_meta}010$pfont)(.*?)${bib::cs_meta}0111/$1$2{bib::cs_meta}011$pfont/;
         } else {
-          s/(${bib::cs_meta}010$pfont)(.*)${bib::cs_meta}0111/$1$2{bib'cs_meta}011$pfont/;
+          s/(${bib::cs_meta}010$pfont)(.*)${bib::cs_meta}0111/$1$2{bib::cs_meta}011$pfont/;
         }
       }
       while (@fontstack != 0) {
@@ -329,7 +329,7 @@ sub font_noprev {
 #       It should be required at the top of this file, so it's always loaded.
 #
 sub nocharset {
-  &bp_cs_none'fromcanon(@_);
+  &bp_cs_none::fromcanon(@_);
 }
 
 1;

--- a/lib/bp-p-debug.pl
+++ b/lib/bp-p-debug.pl
@@ -35,7 +35,7 @@ sub panic {
     local($i,$_);
     local($p,$f,$l,$s,$h,$w,$a,@a,@sub);
     for ($i = 1; ($p,$f,$l,$s,$h,$w) = caller($i); $i++) {
-      @a = @DB'args;
+      @a = @DB::args;
       for (@a) {
             if (/^StB\000/ && length($_) == length($_main{'_main'})) {
                 $_ = sprintf("%s",$_);

--- a/lib/bp-p-dload.pl
+++ b/lib/bp-p-dload.pl
@@ -272,7 +272,7 @@ sub reg_format {
   # Go through all of our functions, and assign to stdbib.
 
   foreach $f ( @glb_expfuncs ) {
-    $formats{$lname, $f} = "bib'${f}_stdbib";
+    $formats{$lname, $f} = "bib::${f}_stdbib";
   }
 
   # next, walk through all the arguments they gave us
@@ -286,16 +286,16 @@ sub reg_format {
       $formats{$lname, 'i_suffix'} = $f;
       next;
     } elsif ( ($f) = /^(\w+) is standard$/) {
-      $inst = "bib'${f}_stdbib";
+      $inst = "bib::${f}_stdbib";
     } elsif ( ($f, $p) = /^(\w+) is unimplemented$/) {
-      $inst = "bib'${f}_unimpl_stdbib";
+      $inst = "bib::${f}_unimpl_stdbib";
       if (!defined &$inst) {
-        $inst = "bib'generic_unimpl_stdbib";
+        $inst = "bib::generic_unimpl_stdbib";
       }
     } elsif ( ($f, $p) = /^(\w+) is unsupported$/) {
-      $inst = "bib'${f}_unsup_stdbib";
+      $inst = "bib::${f}_unsup_stdbib";
       if (!defined &$inst) {
-        $inst = "bib'generic_unsup_stdbib";
+        $inst = "bib::generic_unsup_stdbib";
       }
     } elsif ( ($f) = /^(\w+)$/) {
       $inst = $pname . "'" . $f;

--- a/lib/bp-p-errors.pl
+++ b/lib/bp-p-errors.pl
@@ -31,7 +31,7 @@
 # one record.
 #
 # The values returned are the values previous to the effect of this command.
-# In other words, although a call to bib'errors('clear') will clear out all
+# In other words, although a call to bib::errors('clear') will clear out all
 # our totals and strings, it will return to you the old totals and strings.
 # So you could call clear, but check the return values for any special
 # situations.  Note that the strings are cleared upon clear, report, or

--- a/lib/bp-p-option.pl
+++ b/lib/bp-p-option.pl
@@ -117,7 +117,7 @@ sub parse_num_option {
 
 #
 # This routine is given an option string like "informat=refer" and does the
-# appropriate action.  It will be called by bib'options and by bib'stdargs.
+# appropriate action.  It will be called by bib::options and by bib::stdargs.
 # If it doesn't recognize the option it will return undef.
 #
 sub parse_option {

--- a/lib/bp-tib.pl
+++ b/lib/bp-tib.pl
@@ -121,7 +121,7 @@ sub tocanon {
   local(%entry) = @_;
   local(%can);
 
-  %can = &bp_refer'tocanon(%entry);
+  %can = &bp_refer::tocanon(%entry);
 
   if (defined $can{'o'}) {
     $can{'Edition'} = $can{'o'};

--- a/lib/bp.pl
+++ b/lib/bp.pl
@@ -131,25 +131,25 @@ $glb_version = '0.2.97 (19 Dec 96)';
 #
 #           [ file bp-p-util ]
 #
-#    bp_util'mname_to_canon($names_string);
-#    bp_util'mname_to_canon($names_string, $flag_reverse_author);
+#    bp_util::mname_to_canon($names_string);
+#    bp_util::mname_to_canon($names_string, $flag_reverse_author);
 #
-#    bp_util'name_to_canon($name_string);
-#    bp_util'name_to_canon($name_string, $flag_reverse_author);
+#    bp_util::name_to_canon($name_string);
+#    bp_util::name_to_canon($name_string, $flag_reverse_author);
 #
-#    bp_util'canon_to_name($name_string);
-#    bp_util'canon_to_name($name_string, $how_formatted);
+#    bp_util::canon_to_name($name_string);
+#    bp_util::canon_to_name($name_string, $how_formatted);
 #
-#    bp_util'parsename($name_string);
-#    bp_util'parsename($name_string, $how_formatted);
+#    bp_util::parsename($name_string);
+#    bp_util::parsename($name_string, $how_formatted);
 #
-#    bp_util'parsedate($date_string);
+#    bp_util::parsedate($date_string);
 #
-#    bp_util'canon_month($month_string);
+#    bp_util::canon_month($month_string);
 #
-#    bp_util'genkey(%canon_record);
+#    bp_util::genkey(%canon_record);
 #
-#    bp_util'regkey($key);
+#    bp_util::regkey($key);
 #
 #
 # Internal functions:
@@ -269,7 +269,7 @@ $glb_current_fh  = undef;
 #
 # The auto package only sets these to a format approved by load_format.
 #
-# XXXXX  clear should call auto'clear which then calls real clear.
+# XXXXX  clear should call auto::clear which then calls real clear.
 #
 %glb_Irfmt =  ();
 %glb_Ircset = ();
@@ -416,18 +416,18 @@ $opt_default_debug_level = 8000;
 
 require "${glb_bpprefix}p-debug.pl";
 # loads:
-# bib'assert
-# bib'panic
-# bib'debugs
-# bib'check_consist
-# bib'debug_dump
-# bib'okprint
+# bib::assert
+# bib::panic
+# bib::debugs
+# bib::check_consist
+# bib::debug_dump
+# bib::okprint
 
 require "${glb_bpprefix}p-errors.pl";
 # loads:
-# bib'errors
-# bib'goterror
-# bib'gotwarn
+# bib::errors
+# bib::goterror
+# bib::gotwarn
 
 
 ######
@@ -522,28 +522,28 @@ sub format {
 
 require "${glb_bpprefix}p-dload.pl";
 # loads:
-# bib'load_format
-# bib'load_charset
-# bib'find_bp_files
-# bib'reg_format
+# bib::load_format
+# bib::load_charset
+# bib::find_bp_files
+# bib::reg_format
 
 ######
 
 require "${glb_bpprefix}p-cs.pl";
 # loads:
 # variables used by the cs routines
-# bib'nocharset
-# bib'unicode_to_canon
+# bib::nocharset
+# bib::unicode_to_canon
 
 ######
 
 require "${glb_bpprefix}p-option.pl";
 # loads:
-# bib'stdargs
-# bib'options
-# bib'parse_num_option
-# bib'parse_option
-# bib'doc
+# bib::stdargs
+# bib::options
+# bib::parse_num_option
+# bib::parse_option
+# bib::doc
 
 ######     open("file" [,"format"] );
 
@@ -607,12 +607,12 @@ sub open {
   if ($mode eq 'read') {
     $glb_Ifilename = $name;
     $glb_filelocmap{$name} = 0;
-    $glb_current_fh = "bib'GFMI" . $name;
+    $glb_current_fh = "bib::GFMI" . $name;
     # no strict 'subs';
     $glb_current_fh = STDIN   if $name eq '-';  # magic filehandle
   } else {
     $glb_Ofilename = $name;
-    $glb_current_fh = "bib'GFMO" . $name;
+    $glb_current_fh = "bib::GFMO" . $name;
     # no strict 'subs';
     $glb_current_fh = STDOUT  if $name eq '-';  # magic filehandle
   }
@@ -1184,15 +1184,15 @@ sub clear {
 
 require "${glb_bpprefix}p-stdbib.pl";
 # loads:
-# bib'open_stdbib
-# bib'close_stdbib
-# bib'read_stdbib
-# bib'write_stdbib
-# bib'clear_stdbib
-# bib'implode_stdbib
-# bib'explode_stdbib
-# bib'tocanon_stdbib
-# bib'fromcanon_stdbib
+# bib::open_stdbib
+# bib::close_stdbib
+# bib::read_stdbib
+# bib::write_stdbib
+# bib::clear_stdbib
+# bib::implode_stdbib
+# bib::explode_stdbib
+# bib::tocanon_stdbib
+# bib::fromcanon_stdbib
 
 ######
 #
@@ -1203,10 +1203,10 @@ require "${glb_bpprefix}p-stdbib.pl";
 
 require "${glb_bpprefix}p-utils.pl";
 # loads:
-# bp_util'mname_to_canon
-# bp_util'name_to_canon
-# bp_util'canon_to_name
-# bp_util'parsedate
+# bp_util::mname_to_canon
+# bp_util::name_to_canon
+# bp_util::canon_to_name
+# bp_util::parsedate
 
 ##################
 #
@@ -1214,9 +1214,9 @@ require "${glb_bpprefix}p-utils.pl";
 #
 
 
-if (defined $main'bibpackage_do_not_load_defaults) {
+if (defined $main::bibpackage_do_not_load_defaults) {
   # special trickery for debugging and profiling.
-  $main'bibpackage_do_not_load_defaults = 1; # stop one-use warning
+  $main::bibpackage_do_not_load_defaults = 1; # stop one-use warning
   &debugs("bp package loaded without defaults", 65536);
 } else {
   &format("auto") || die &goterror("Could not load default format.", "package");

--- a/misc/C3toTab.pl
+++ b/misc/C3toTab.pl
@@ -136,7 +136,7 @@ package bp_cs_$package;
 \$bib::charsets{'$name', 'i_name'} = '$name';
 \$bib::charsets{'$name', 'i_protection'} = 0;
 
-\$bib::charsets{'$name', 'tocanon'}  = "bp_cs_${package}'tocanon";
+\$bib::charsets{'$name', 'tocanon'}  = "bp_cs_${package}::tocanon";
 \$bib::charsets{'$name', 'fromcanon'}  = "bp_cs_${package}'fromcanon";
 
 ######

--- a/tests/bptest.pl
+++ b/tests/bptest.pl
@@ -105,7 +105,9 @@ sub check {
     if (length($outstr) > (20 * $screenlength) ) {
       print "\n$routine failed.  Output is too long to print (", length($outstr), " chars).\n";
     } elsif (length($outstr) > 120) {
-      print "\n$routine failed.  Output comparison:\n";
+      print "\n$routine failed.\n";
+      print "Input: "; print @input; print "\n";
+      print "Output comparison:\n";
       &longcomp($output, $res);
     } else {
       print $outstr;

--- a/tests/newcset.pl
+++ b/tests/newcset.pl
@@ -141,19 +141,19 @@ $canran = $randstring;
 # get rid of characters we don't handle.
 $c = $caniso;
 $c =~ s/[\200-\237\246\255\262\263\271\274\275\276\320\327\335\336\360\375\376]//g;
-$appiso = &bp_cs_apple'fromcanon($c);
-&check('partial', "apple'fromcanon", 1, 1);
-&check('', "bp_cs_apple'tocanon", $c, $appiso);
+$appiso = &bp_cs_apple::fromcanon($c);
+&check('partial', "apple::fromcanon", 1, 1);
+&check('', "bp_cs_apple::tocanon", $c, $appiso);
 $c = $appiso = undef;
 
 $c = $canran;
 $c =~ s/[\200-\237\246\255\262\263\271\274\275\276\320\327\335\336\360\375\376]//g;
-$appran = &bp_cs_apple'fromcanon($c);
-&check('partial', "apple'fromcanon", 1, 1);
-&check('', "bp_cs_apple'tocanon", $c, $appran);
+$appran = &bp_cs_apple::fromcanon($c);
+&check('partial', "apple::fromcanon", 1, 1);
+&check('', "bp_cs_apple::tocanon", $c, $appran);
 $c = $appran = undef;
 
-&check('', "bp_cs_apple'fromcanon", '&', $cantest);
+&check('', "bp_cs_apple::fromcanon", '&', $cantest);
 
 &endtest;
 
@@ -162,18 +162,18 @@ $c = $appran = undef;
 &testcharset("troff", 5);
 
 ($c = $caniso) =~ s/[\200-\237]//g;  # troff can't handle these
-$troiso = &bp_cs_troff'fromcanon($c);
-&check('partial', "troff'fromcanon", 1, 1);
-&check('', "bp_cs_troff'tocanon", $c, $troiso);
+$troiso = &bp_cs_troff::fromcanon($c);
+&check('partial', "troff::fromcanon", 1, 1);
+&check('', "bp_cs_troff::tocanon", $c, $troiso);
 $c = $troiso = undef;
 
 ($c = $canran) =~ s/[\200-\237]//g;  # troff can't handle these
-$troran = &bp_cs_troff'fromcanon($c);
-&check('partial', "troff'fromcanon", 1, 1);
-&check('', "bp_cs_troff'tocanon", $c, $troran);
+$troran = &bp_cs_troff::fromcanon($c);
+&check('partial', "troff::fromcanon", 1, 1);
+&check('', "bp_cs_troff::tocanon", $c, $troran);
 $c = $troran = undef;
 
-&check('', "bp_cs_troff'fromcanon", '&', $cantest);
+&check('', "bp_cs_troff::fromcanon", '&', $cantest);
 
 &endtest;
 
@@ -181,20 +181,20 @@ $c = $troran = undef;
 
 &testcharset("tex", 3);
 ($c = $caniso) =~ s/[\200-\337]//g;  # TeX can't handle these
-$texiso = &bp_cs_tex'fromcanon($c, 1);
-&check('partial', "tex'fromcanon", 1, 1);
-&check('', "bp_cs_tex'tocanon", $c, $texiso, 1);
+$texiso = &bp_cs_tex::fromcanon($c, 1);
+&check('partial', "tex::fromcanon", 1, 1);
+&check('', "bp_cs_tex::tocanon", $c, $texiso, 1);
 $c = $texiso = undef;
 
 # XXXXX Fix me!  Something in here is broken.
 
 #($c = $canran) =~ s/[\200-\237]//g;
-#$texran = &bp_cs_tex'fromcanon($c, 1);
-#&check('partial', "tex'fromcanon", 1, 1);
-#&check('', "bp_cs_tex'tocanon", $c, $texran, 1);
+#$texran = &bp_cs_tex::fromcanon($c, 1);
+#&check('partial', "tex::fromcanon", 1, 1);
+#&check('', "bp_cs_tex::tocanon", $c, $texran, 1);
 #$c = $texran = undef;
 
-&check('', "bp_cs_tex'fromcanon", '&', $cantest);
+&check('', "bp_cs_tex::fromcanon", '&', $cantest);
 
 &endtest;
 
@@ -202,28 +202,28 @@ $c = $texiso = undef;
 
 &testcharset("html", 7);
 
-&check('', "bp_cs_html'fromcanon", '&amp;', $cantest);
-&check('', "bp_cs_html'tocanon", pack("C", 199), '&Ccedil;' );
+&check('', "bp_cs_html::fromcanon", '&amp;', $cantest);
+&check('', "bp_cs_html::tocanon", pack("C", 199), '&Ccedil;' );
 # This should generate a warning
 $oldwlev = $bib::glb_warn_level;
 $bib::glb_warn_level = 0;
-&check('', "bp_cs_html'tocanon", '', '&fo??o*+?/g;' );
+&check('', "bp_cs_html::tocanon", '', '&fo??o*+?/g;' );
 $bib::glb_warn_level = $oldwlev;
 
 $c = $caniso;
-$htmiso = &bp_cs_html'fromcanon($c);
-&check('partial', "html'fromcanon", 1, 1);
-$t = &bp_cs_html'tocanon($htmiso);
+$htmiso = &bp_cs_html::fromcanon($c);
+&check('partial', "html::fromcanon", 1, 1);
+$t = &bp_cs_html::tocanon($htmiso);
 $t =~ s/${bib::cs_ext}0026/&/g;  # html leaves & characters in extended form.
-&check('norun', "bp_cs_html'tocanon", $c, $t);
+&check('norun', "bp_cs_html::tocanon", $c, $t);
 $c = $htmiso = $t = undef;
 
 $c = $canran;
-$htmran = &bp_cs_html'fromcanon($c);
-&check('partial', "html'fromcanon", 1, 1);
-$t = &bp_cs_html'tocanon($htmran);
+$htmran = &bp_cs_html::fromcanon($c);
+&check('partial', "html::fromcanon", 1, 1);
+$t = &bp_cs_html::tocanon($htmran);
 $t =~ s/${bib::cs_ext}0026/&/g;  # html leaves & characters in extended form.
-&check('norun', "bp_cs_html'tocanon", $c, $t);
+&check('norun', "bp_cs_html::tocanon", $c, $t);
 $c = $htmran = $t = undef;
 
 &endtest;
@@ -243,10 +243,10 @@ $f = $failed;
 for $iso ( "\000" .. "\377" ) {
   next if $iso =~ /[\200-\237]/;
   $can = &bp_cs_88591'tocanon($iso);
-  $imd = &bp_cs_troff'fromcanon($can);
-  $can = &bp_cs_troff'tocanon($imd);
-  $imd = &bp_cs_html'fromcanon($can);
-  $can = &bp_cs_html'tocanon($imd);
+  $imd = &bp_cs_troff::fromcanon($can);
+  $can = &bp_cs_troff::tocanon($imd);
+  $imd = &bp_cs_html::fromcanon($can);
+  $can = &bp_cs_html::tocanon($imd);
   $isr = &bp_cs_88591'fromcanon($can);
   &check('nostatus,norun', "cs conversion loop ".ord($iso), $iso, $isr);
 }
@@ -254,37 +254,37 @@ $can = $imd = $isr = undef;
 &check('partial', "cs conversion loop", $f, $failed);
 
 $can = &bp_cs_88591'tocanon($isostring);
-$imd = &bp_cs_html'fromcanon($can);
-$can = &bp_cs_html'tocanon($imd);
+$imd = &bp_cs_html::fromcanon($can);
+$can = &bp_cs_html::tocanon($imd);
 $isr = &bp_cs_88591'fromcanon($can);
 &check('norun', "iso conversion loop 1", $isostring, $isr);
 $can = $imd = $isr = undef;
 
 ($iso = $isostring) =~ s/[\200-\237]//g;
 $can = &bp_cs_88591'tocanon($iso);
-$imd = &bp_cs_troff'fromcanon($can);
-$can = &bp_cs_troff'tocanon($imd);
-$imd = &bp_cs_html'fromcanon($can);
-$can = &bp_cs_html'tocanon($imd);
+$imd = &bp_cs_troff::fromcanon($can);
+$can = &bp_cs_troff::tocanon($imd);
+$imd = &bp_cs_html::fromcanon($can);
+$can = &bp_cs_html::tocanon($imd);
 $isr = &bp_cs_88591'fromcanon($can);
 &check('norun', "iso conversion loop 2", $iso, $isr);
 $can = $imd = $isr = undef;  # leave $iso
 
 $iso =~ s/[\200-\237\246\255\262\263\271\274\275\276\320\327\335\336\360\375\376]//g;
 $can = &bp_cs_88591'tocanon($iso);
-$imd = &bp_cs_troff'fromcanon($can);
-$can = &bp_cs_troff'tocanon($imd);
-$imd = &bp_cs_apple'fromcanon($can);
-$can = &bp_cs_apple'tocanon($imd);
-$imd = &bp_cs_html'fromcanon($can);
-$can = &bp_cs_html'tocanon($imd);
+$imd = &bp_cs_troff::fromcanon($can);
+$can = &bp_cs_troff::tocanon($imd);
+$imd = &bp_cs_apple::fromcanon($can);
+$can = &bp_cs_apple::tocanon($imd);
+$imd = &bp_cs_html::fromcanon($can);
+$can = &bp_cs_html::tocanon($imd);
 $isr = &bp_cs_88591'fromcanon($can);
 &check('norun', "iso conversion loop 3", $iso, $isr);
 $can = $imd = $isr = $iso = undef;
 
 $can = &bp_cs_88591'tocanon($randstring);
-$imd = &bp_cs_html'fromcanon($can);
-$can = &bp_cs_html'tocanon($imd);
+$imd = &bp_cs_html::fromcanon($can);
+$can = &bp_cs_html::tocanon($imd);
 $rnr = &bp_cs_88591'fromcanon($can);
 &check('norun', "random conversion loop 1", $randstring, $rnr);
 $can = $imd = $rnr = undef;
@@ -296,9 +296,9 @@ $can = $imd = $rnr = undef;
 $bp_cs_html'opt_html3 = 1;
 &begintest("HTML 3", 4);
 
-&check('', "bp_cs_html'tocanon", pack("C", 222), '&THORN;' );
-&check('', "bp_cs_html'tocanon", pack("C", 165), '&#165;' );
-&check('', "bp_cs_html'tocanon", "${bib::cs_ext}AB7F", '&U+AB7F;' );
-&check('', "bp_cs_html'fromcanon", '&U+AB7F;', "${bib::cs_ext}AB7F" );
+&check('', "bp_cs_html::tocanon", pack("C", 222), '&THORN;' );
+&check('', "bp_cs_html::tocanon", pack("C", 165), '&#165;' );
+&check('', "bp_cs_html::tocanon", "${bib::cs_ext}AB7F", '&U+AB7F;' );
+&check('', "bp_cs_html::fromcanon", '&U+AB7F;', "${bib::cs_ext}AB7F" );
 
 &endtest;

--- a/tests/sub/datetest.pl
+++ b/tests/sub/datetest.pl
@@ -6,7 +6,7 @@ if ( (!defined $intest) || ($intest != 1) ) {
 }
 
 $failed = 0;
-print "testing bp_util'parsedate..........................";
+print "testing bp_util::parsedate..........................";
 
 open(DFILE, "data/dates.dat") || die "datetest: can't open data file.\n";
 

--- a/tests/sub/nametest.pl
+++ b/tests/sub/nametest.pl
@@ -16,7 +16,7 @@ sub failp {
 }
 
 $failed = 0;
-print "testing bp_util'mname_to_canon.....................";
+print "testing bp_util::mname_to_canon.....................";
 
 open(NAMEFILE, "data/namesm.dat") || die "nametest: can't open data file.\n";
 
@@ -38,7 +38,7 @@ close(NAMEFILE);
 print (($failed) ? "$failed errors\n" : "ok\n");
 
 $failed = 0;
-print "testing bp_util'name_to_canon......................";
+print "testing bp_util::name_to_canon......................";
 
 open(NAMEFILE, "data/names.dat") || die "nametest: can't open data file.\n";
 
@@ -60,7 +60,7 @@ close(NAMEFILE);
 print (($failed) ? "$failed errors\n" : "ok\n");
 
 $failed = 0;
-print "testing bp_util'name_to_canon..............(long)..";
+print "testing bp_util::name_to_canon..............(long)..";
 
 $bp_util::opt_complex = 10;
 


### PR DESCRIPTION
Perl's behavior has changed incompatibly.  With this pull request:
 * bibtex2web works on newer versions of Perl 5.
 * bibtex2web fails on older versions of Perl 5.

I don't see an easy way to make bibtex2web work on both old and new versions of Perl 5, while retaining strict warnings.